### PR TITLE
Fix overlay permission status logic

### DIFF
--- a/app/src/main/java/com/shaiws/redalert/MainActivity.kt
+++ b/app/src/main/java/com/shaiws/redalert/MainActivity.kt
@@ -399,9 +399,9 @@ class MainActivity : FragmentActivity() {
         findViewById<TextView>(R.id.overlayPermissionStatus).apply {
             text =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(this@MainActivity))
-                    context.getString(R.string.grantedPermissions)
-                else
                     context.getString(R.string.deniedPermissions)
+                else
+                    context.getString(R.string.grantedPermissions)
         }
 
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -9,14 +9,14 @@
     <string name="langSelect">اختر اللغة</string>
     <string name="activeService">حالة الخدمة: نشطة</string>
     <string name="deactiveService">حالة الخدمة: غير نشطة</string>
-    <string name="grantedPermissions">إذن الظهور فوق التطبيقات: معطل</string>
+    <string name="grantedPermissions">إذن الظهور فوق التطبيقات: ممكّن</string>
     <string name="deactiveBattery">تحسين الطاقة: معطل</string>
     <string name="activeBattery">تحسين استهلاك الطاقة: ممكّن</string>
     <string name="serviceActive">الخدمة نشطة</string>
     <string name="serviceDeactive">الخدمة غير نشطة</string>
     <string name="overlayGranted">تم منح الإذن بالظهور فوق النوافذ الأخرى</string>
     <string name="overlayDenied">لم يتم منح الإذن بالظهور فوق النوافذ الأخرى</string>
-    <string name="deniedPermissions">إذن الظهور فوق التطبيقات: ممكّن</string>
+    <string name="deniedPermissions">إذن الظهور فوق التطبيقات: معطل</string>
     <string name="thisIsATest">هذا اختبار</string>
     <string name="test1">هذا هو الاختبار رقم 1</string>
     <string name="test2">هذا هو الاختبار رقم 2</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -9,14 +9,14 @@
     <string name="langSelect">Choose language</string>
     <string name="activeService">Service status: active</string>
     <string name="deactiveService">Service status: inactive</string>
-    <string name="grantedPermissions">Permission to appear above apps: disabled</string>
+    <string name="grantedPermissions">Permission to appear above apps: enabled</string>
     <string name="deactiveBattery">Energy optimization: disabled</string>
     <string name="activeBattery">Power consumption optimization: enabled</string>
     <string name="serviceActive">The service is active</string>
     <string name="serviceDeactive">The service is inactive</string>
     <string name="overlayGranted">Permission to appear on top of other windows has been granted</string>
     <string name="overlayDenied">Permission to appear on top of other windows has not been granted</string>
-    <string name="deniedPermissions">Permission to appear above apps: enabled</string>
+    <string name="deniedPermissions">Permission to appear above apps: disabled</string>
     <string name="thisIsATest">This is a test</string>
     <string name="test1">This is test number 1</string>
     <string name="test2">This is test number 2</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -9,14 +9,14 @@
     <string name="langSelect">Выберите язык</string>
     <string name="activeService">Статус услуги: Активный</string>
     <string name="deactiveService">Статус услуги: неактивен</string>
-    <string name="grantedPermissions">Разрешение появляться над приложениями: не включено</string>
+    <string name="grantedPermissions">Разрешение появляться над приложениями: включено</string>
     <string name="deactiveBattery">Оптимизация энергопотребления: не включено</string>
     <string name="activeBattery">Оптимизация энергопотребления: включено</string>
     <string name="serviceActive">Услуга активна</string>
     <string name="serviceDeactive">Услуга не активна</string>
     <string name="overlayGranted">Разрешение на показ поверх других окон предоставлено.</string>
     <string name="overlayDenied">Разрешение на появление поверх других окон не предоставлено.</string>
-    <string name="deniedPermissions">Разрешение появляться над приложениями: включено.</string>
+    <string name="deniedPermissions">Разрешение появляться над приложениями: не включено.</string>
     <string name="thisIsATest">Это тест</string>
     <string name="test1">Это тест №1</string>
     <string name="test2">Это тест №2</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,14 +9,14 @@
     <string name="langSelect">בחר שפה</string>
     <string name="activeService">מצב השירות: פעיל</string>
     <string name="deactiveService">מצב השירות: לא פעיל</string>
-    <string name="grantedPermissions">הרשאה להופיע מעל אפליקציות: לא מופעלת</string>
+    <string name="grantedPermissions">הרשאה להופיע מעל אפליקציות: מופעלת</string>
     <string name="deactiveBattery">אופטימיזציה של צריכת אנרגיה: לא מופעלת</string>
     <string name="activeBattery">אופטימיזציה של צריכת אנרגיה: מופעלת</string>
     <string name="serviceActive">השירות פעיל</string>
     <string name="serviceDeactive">השירות לא פעיל</string>
     <string name="overlayGranted">הרשאה להופיע מעל חלונות אחרים ניתנה</string>
     <string name="overlayDenied">הרשאה להופיע מעל חלונות אחרים לא ניתנה</string>
-    <string name="deniedPermissions">הרשאה להופיע מעל אפליקציות: מופעלת</string>
+    <string name="deniedPermissions">הרשאה להופיע מעל אפליקציות: לא מופעלת</string>
     <string name="thisIsATest">זוהי בדיקה</string>
     <string name="test1">זוהי בדיקה 1</string>
     <string name="test2">זוהי בדיקה 2</string>


### PR DESCRIPTION
## Summary
- show `deniedPermissions` when overlay permission is missing
- show `grantedPermissions` when overlay permission is granted
- update translations to match the new logic

## Testing
- `./gradlew test --no-daemon` *(fails: Gradle download starts but build does not finish)*

------
https://chatgpt.com/codex/tasks/task_e_6845ecff41f48328a0a7454bb48e2afd